### PR TITLE
Fix URI::InvalidURIError with accented characters

### DIFF
--- a/carrierwave-colore.gemspec
+++ b/carrierwave-colore.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.homepage       = ''
 
   gem.add_dependency 'colore-client', '>= 0.2.0'
+  gem.add_dependency 'activesupport'
 
   gem.files          = `git ls-files`.split($/)
   gem.test_files     = gem.files.grep %r[^(test|spec|features)]

--- a/lib/carrierwave/colore.rb
+++ b/lib/carrierwave/colore.rb
@@ -1,4 +1,5 @@
 require 'colore-client'
+require 'active_support/inflector'
 
 module CarrierWave
   module Colore

--- a/lib/carrierwave/storage/colore.rb
+++ b/lib/carrierwave/storage/colore.rb
@@ -75,9 +75,16 @@ module CarrierWave
         #
         # @param  file [CarrierWave::SanitizedFile]
         def store(new_file)
+          filename = new_file.filename
+
+          # Strip URL-unfriendly characters if we've got ActiveSupport around
+          if filename.respond_to?(:parameterize)
+            filename = filename.parameterize
+          end
+
           response = @connection.create_document(
             doc_id:   @store_path,
-            filename: new_file.filename,
+            filename: filename,
             content:  new_file.to_file
           )
           @filename = response["path"]

--- a/lib/carrierwave/storage/colore.rb
+++ b/lib/carrierwave/storage/colore.rb
@@ -75,16 +75,9 @@ module CarrierWave
         #
         # @param  file [CarrierWave::SanitizedFile]
         def store(new_file)
-          filename = new_file.filename
-
-          # Strip URL-unfriendly characters if we've got ActiveSupport around
-          if filename.respond_to?(:parameterize)
-            filename = filename.parameterize
-          end
-
           response = @connection.create_document(
             doc_id:   @store_path,
-            filename: filename,
+            filename: new_file.filename.parameterize, # Strip URL-unfriendly characters
             content:  new_file.to_file
           )
           @filename = response["path"]


### PR DESCRIPTION
Accented characters in filenames produce `URI::InvalidURIError` exceptions at upload time.
Didn't add the active support dependency in gemspec to prevent dependency hell.